### PR TITLE
fix: improve GET all reviews and POST new review entry

### DIFF
--- a/src/features/review/schema.ts
+++ b/src/features/review/schema.ts
@@ -1,7 +1,10 @@
-import { ReviewSchema } from "@prisma/generated/zod";
+import { VideoSchema, ReviewSchema } from "@prisma/generated/zod";
 
-export const CreateReviewSchema = ReviewSchema.pick({
-  videoId: true,
+export const CreateReviewParamSchema = VideoSchema.pick({
+  platformVideoId: true
+});
+
+export const CreateReviewBodySchema = ReviewSchema.pick({
   rating: true,
   text: true
 });


### PR DESCRIPTION
## Overview
Why: missed/inaccurate identifier to retrieve all reviews and create new review entry
What: adding correct params to the route
How: add videoId as params both to GET reviews and POST new review entry

## Changes
1. Add videoId params to GET all reviews route
2. Restructure initial body request to params (videoId) and new body request (only text and rating)